### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/proof-html.yml
+++ b/.github/workflows/proof-html.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: anishathalye/proof-html@v1.1.0


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/mern-sandbox/security/code-scanning/2](https://github.com/conorheffron/mern-sandbox/security/code-scanning/2)

The best way to fix the problem is to add a `permissions` block to the workflow or to the specific job(s). Since there is only one job (`build`), and the workflow does not appear to require any write permissions for GITHUB_TOKEN (e.g., there are no steps that push code, make release assets, comment on PRs, etc.), setting `permissions: read-all` at the job level is sufficient and safest for now. This reduces the risk of the GITHUB_TOKEN being used with excessive permissions. Place the `permissions:` block under the `build:` job, above `runs-on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
