### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/mern-sandbox/security/code-scanning/1](https://github.com/conorheffron/mern-sandbox/security/code-scanning/1)

To fix the issue, add a `permissions` block that explicitly sets the minimal required GitHub token permissions for the workflow, in line with the principle of least privilege. Because the workflow only checks out code and runs builds/tests, it is safe to set `contents: read`. This can be set as a root-level key in the workflow YAML (above the `jobs:` key) so it applies to all jobs unless specifically overridden. No method or definition changes are required, just the addition of:

```yaml
permissions:
  contents: read
```

at the top level of `.github/workflows/node.js.yml`, preferably between the `name:` and `on:` blocks (after line 4 and before line 6).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
